### PR TITLE
Add Android flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ The default is `github-pr-check`.
 Optional. Fails the current check if any error was found [`true`/`false`]
 The default value is false.
 
+### `android`
+
+Optional. Runs KtLint with [Android Kotlin Style Guide](https://android.github.io/kotlin-guides/style.html) [`true`/`false`]
+The default value is false.
+
 ## Example usage
 
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
       Default is false.
     required: false
     default: 'false'
+  android:
+    description: Run KtLint with Android Kotlin Style Guide
+    required: false
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -30,6 +34,7 @@ runs:
     - ${{ inputs.level }}
     - ${{ inputs.reporter }}
     - ${{ inputs.fail_on_error }}
+    - ${{ inputs.android }}
 branding:
   icon: 'edit'
   color: 'blue'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
 
+export ANDROID=
+
 if [ "$INPUT_FAIL_ON_ERROR" = true ] ; then
   set -o pipefail
+fi
+
+if [ "$INPUT_ANDROID" = true ] ; then
+  export ANDROID=--android
 fi
 
 cd "$GITHUB_WORKSPACE"
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-ktlint --reporter=checkstyle \
+ktlint --reporter=checkstyle $ANDROID \
   | reviewdog -f=checkstyle -name="ktlint" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}"


### PR DESCRIPTION
Added Android flag support `--android` to support Android Kotlin Style

Tell me if `entrypoint.sh` needs other edits, I'm not a bash expert