### PR TITLE
Add relative flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ The default is `github-pr-check`.
 Optional. Fails the current check if any error was found [`true`/`false`]
 The default value is false.
 
+### `relative`
+
+Optional. Print files relative to the working directory [`true`/`false`]
+The default value is false.
+
 ## Example usage
 
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
       Default is false.
     required: false
     default: 'false'
+  relative:
+    description: Print files relative to the working directory
+    required: false
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -30,6 +34,7 @@ runs:
     - ${{ inputs.level }}
     - ${{ inputs.reporter }}
     - ${{ inputs.fail_on_error }}
+    - ${{ inputs.relative }}
 branding:
   icon: 'edit'
   color: 'blue'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
 
+export RELATIVE=
+
 if [ "$INPUT_FAIL_ON_ERROR" = true ] ; then
   set -o pipefail
+fi
+
+if [ "$INPUT_RELATIVE" = true ] ; then
+  export RELATIVE=--relative
 fi
 
 cd "$GITHUB_WORKSPACE"
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-ktlint --reporter=checkstyle \
+ktlint --reporter=checkstyle $RELATIVE \
   | reviewdog -f=checkstyle -name="ktlint" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}"


### PR DESCRIPTION
Added relative flag support `--relative` to support relative paths instead of absolute ones.

The default value is `false`, but in my opinion, it should be `true` since I don't want to see absolute path (ex: `/home/github/actions/...`) in my Github Actions logs