### PR TITLE
Feature: Support reviewdog filter mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ The default is `github-pr-check`.
 Optional. Fails the current check if any error was found [`true`/`false`]
 The default value is false.
 
+### `filter_mode`
+Optional. Filter mode of reviewdog command [`added`,`diff_context`,`file`,`nofilter`]
+Default is `added`.
+
 ### `relative`
 
 Optional. Print files relative to the working directory [`true`/`false`]

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,12 @@ inputs:
       Default is false.
     required: false
     default: 'false'
+  filter_mode:
+    description: |
+      Filter mode of reviewdog command [added,diff_context,file,nofilter]
+      Default is added.
+    required: false
+    default: 'added'
   relative:
     description: Print files relative to the working directory
     required: false
@@ -38,6 +44,7 @@ runs:
     - ${{ inputs.level }}
     - ${{ inputs.reporter }}
     - ${{ inputs.fail_on_error }}
+    - ${{ inputs.filter_mode }}
     - ${{ inputs.relative }}
     - ${{ inputs.android }}
 branding:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,4 +21,4 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 echo KtLint version: "$(ktlint --version)"
 ktlint --reporter=checkstyle $RELATIVE $ANDROID \
-  | reviewdog -f=checkstyle -name="ktlint" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}"
+  | reviewdog -f=checkstyle -name="ktlint" -reporter="${INPUT_REPORTER}" -filter-mode="${INPUT_FILTER_MODE}" -level="${INPUT_LEVEL}"


### PR DESCRIPTION
### What
Support reviewdog's filter mode : https://github.com/reviewdog/reviewdog#filter-mode

### Why
Some important ktlint findings do not appear in the PR diff, e.g. 
* When a file is moved to another directory and now an import is unnecessary
* When the usage of a class is removed from the file, and now the import is unused
* Needless blank lines is not catched as well for some reason

In above cases, `filter-mode=file` can be used. In other projects, we could enforce failing even when unrelated findings. are found with `filter-mode= nofilter`.

### How
By adding a new optional input `filter_mode` with a default value

### Note
Tested in a private repo