### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,8 @@ fi
 
 cd "$GITHUB_WORKSPACE"
 
+git config --global --add safe.directory $GITHUB_WORKSPACE
+
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 echo ktlint version: "$(ktlint --version)"


### PR DESCRIPTION
The GitHub Actions fails Due to Git v2.35.2 spec changes.
https://github.com/reviewdog/reviewdog/issues/1158#issue-1202862728