### PR TITLE
chore: Update review dog version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.14.2
 
-ENV REVIEWDOG_VERSION=v0.13.1
+ENV REVIEWDOG_VERSION=v0.14.1
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 


### PR DESCRIPTION
Since the version in use is from December 2021 and Ktlint has some problems in the android-sc repo https://github.com/ScaCap/sc-android/actions I wanted to update and see if that makes it better overall