### PR TITLE
Allow a glob to be specified for the files to be checked

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
     description: Defines the ktlint version to use
     required: false
     default: 'latest'
+  file_glob:
+    description: Optionally defines a file glob to identify files to be checked
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 echo ktlint version: "$(ktlint --version)"
 
-ktlint --reporter=checkstyle $RELATIVE $ANDROID $BASELINE \
+ktlint --reporter=checkstyle $RELATIVE $ANDROID $BASELINE $INPUT_FILE_GLOB \
   | reviewdog -f=checkstyle \
     -name="ktlint" \
     -reporter="${INPUT_REPORTER}" \


### PR DESCRIPTION
This allows actions to use a glob, [as specified in the ktlint user reference docs](https://pinterest.github.io/ktlint/install/cli/#globs), to limit the ktlint run.

This is useful for folks who have monorepos and import source code from upstream repositories where ktlint may not be enforced.