### PR TITLE
Allow custom reviewdog report name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
     description: Defines the ktlint version to use
     required: false
     default: 'latest'
+  name:
+    description: Reviewdog report name
+    required: false
+    default: 'ktlint'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -57,6 +61,7 @@ runs:
     - ${{ inputs.android }}
     - ${{ inputs.baseline }}
     - ${{ inputs.ktlint_version }}
+    - ${{ inputs.name }}
 branding:
   icon: 'edit'
   color: 'blue'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ echo ktlint version: "$(ktlint --version)"
 
 ktlint --reporter=checkstyle $RELATIVE $ANDROID $BASELINE \
   | reviewdog -f=checkstyle \
-    -name="ktlint" \
+    -name="${INPUT_NAME}" \
     -reporter="${INPUT_REPORTER}" \
     -level="${INPUT_LEVEL}" \
     -filter-mode="${INPUT_FILTER_MODE}" \


### PR DESCRIPTION
We already use the name for another job. The problem is when we want to protect the branches by requiring the check status, both have the same name.