### PR TITLE
chore: fix curl failure by passing GitHub token

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -6,6 +6,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build the Docker image
         run: docker build . --file Dockerfile --tag "reviewdog-ktlint:$(date +%s)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     name: runner / ktlint (github-check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./
         with:
           github_token: ${{ secrets.github_token }}
@@ -19,7 +19,7 @@ jobs:
     name: runner / ktlint (github-pr-check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./
         with:
           github_token: ${{ secrets.github_token }}
@@ -32,7 +32,7 @@ jobs:
     name: runner / ktlint (github-pr-review)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./
         with:
           github_token: ${{ secrets.github_token }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.7
+FROM alpine:3.17.0
 
 ENV REVIEWDOG_VERSION=v0.14.1
 

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,7 @@ runs:
     - ${{ inputs.android }}
     - ${{ inputs.baseline }}
     - ${{ inputs.ktlint_version }}
+    - ${{ secrets.GITHUB_TOKEN }}
 branding:
   icon: 'edit'
   color: 'blue'

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,6 @@ runs:
     - ${{ inputs.android }}
     - ${{ inputs.baseline }}
     - ${{ inputs.ktlint_version }}
-    - ${{ secrets.GITHUB_TOKEN }}
 branding:
   icon: 'edit'
   color: 'blue'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,17 +5,12 @@ export ANDROID=
 export BASELINE=
 
 if [ "$INPUT_KTLINT_VERSION" = "latest" ]; then
-  echo "Downloading latest..."
-  content=$(curl -L https://api.github.com/repos/pinterest/ktlint/releases/latest --header "authorization: Bearer ${INPUT_GITHUB_TOKEN}")
-  echo "$content"
-  url=$(echo "$content" | grep "browser_download_url.*ktlint\"")
-  echo "url: ${url}"
-  cleaned="$(echo "$url" | cut -d : -f 2,3 | tr -d \")"
-  echo "cleaned: $cleaned"
-  echo "$cleaned" | wget -i -
-  chmod a+x ktlint
-  mv ktlint /usr/local/bin/
-  echo "Done downloading."
+  curl -sSL https://api.github.com/repos/pinterest/ktlint/releases/latest --header "authorization: Bearer ${INPUT_GITHUB_TOKEN}" |
+    grep "browser_download_url.*ktlint\"" |
+    cut -d : -f 2,3 |
+    tr -d \" |
+    wget -qi - && chmod a+x ktlint &&
+    mv ktlint /usr/local/bin/
 else
   curl -sSLO https://github.com/pinterest/ktlint/releases/download/"${INPUT_KTLINT_VERSION}"/ktlint &&
     chmod a+x ktlint &&

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,8 +6,9 @@ export BASELINE=
 
 if [ "$INPUT_KTLINT_VERSION" = "latest" ]; then
   echo "Downloading latest..."
-  curl -L https://api.github.com/repos/pinterest/ktlint/releases/latest |
-    grep "browser_download_url.*ktlint\"" |
+  url=$(curl -L https://api.github.com/repos/pinterest/ktlint/releases/latest | grep "browser_download_url.*ktlint\"")
+  echo "url: ${url}"
+  echo "$url" |
     cut -d : -f 2,3 |
     tr -d \" |
     wget -i -

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ export BASELINE=
 
 if [ "$INPUT_KTLINT_VERSION" = "latest" ]; then
   echo "Downloading latest..."
-  content=$(curl -L https://api.github.com/repos/pinterest/ktlint/releases/latest | grep "browser_download_url.*ktlint\"")
+  content=$(curl -L https://api.github.com/repos/pinterest/ktlint/releases/latest)
   echo "$content"
   url=$(echo "$content" | grep "browser_download_url.*ktlint\"")
   echo "url: ${url}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ export BASELINE=
 
 if [ "$INPUT_KTLINT_VERSION" = "latest" ]; then
   echo "Downloading latest..."
-  curl -sSL https://api.github.com/repos/pinterest/ktlint/releases/latest |
+  curl -L https://api.github.com/repos/pinterest/ktlint/releases/latest |
     grep "browser_download_url.*ktlint\"" |
     cut -d : -f 2,3 |
     tr -d \" |
@@ -15,7 +15,7 @@ if [ "$INPUT_KTLINT_VERSION" = "latest" ]; then
   mv ktlint /usr/local/bin/
   echo "Done downloading."
 else
-  curl -sSLO https://github.com/pinterest/ktlint/releases/download/"${INPUT_KTLINT_VERSION}"/ktlint &&
+  curl -LO https://github.com/pinterest/ktlint/releases/download/"${INPUT_KTLINT_VERSION}"/ktlint &&
     chmod a+x ktlint &&
     mv ktlint /usr/local/bin/
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,31 +4,31 @@ export RELATIVE=
 export ANDROID=
 export BASELINE=
 
-if [ "$INPUT_KTLINT_VERSION" = "latest" ] ; then
+if [ "$INPUT_KTLINT_VERSION" = "latest" ]; then
   echo "Downloading latest..."
-  curl -sSL https://api.github.com/repos/pinterest/ktlint/releases/latest \
-    | grep "browser_download_url.*ktlint\"" \
-    | cut -d : -f 2,3 \
-    | tr -d \" \
-    | wget -qi -\
-    && chmod a+x ktlint \
-    && mv ktlint /usr/local/bin/
+  curl -sSL https://api.github.com/repos/pinterest/ktlint/releases/latest |
+    grep "browser_download_url.*ktlint\"" |
+    cut -d : -f 2,3 |
+    tr -d \" |
+    wget -qi -
+  chmod a+x ktlint
+  mv ktlint /usr/local/bin/
   echo "Done downloading."
 else
-  curl -sSLO https://github.com/pinterest/ktlint/releases/download/"${INPUT_KTLINT_VERSION}"/ktlint \
-    && chmod a+x ktlint \
-    && mv ktlint /usr/local/bin/
+  curl -sSLO https://github.com/pinterest/ktlint/releases/download/"${INPUT_KTLINT_VERSION}"/ktlint &&
+    chmod a+x ktlint &&
+    mv ktlint /usr/local/bin/
 fi
 
-if [ "$INPUT_RELATIVE" = true ] ; then
+if [ "$INPUT_RELATIVE" = true ]; then
   export RELATIVE=--relative
 fi
 
-if [ ! -z "$INPUT_BASELINE" ] ; then
+if [ ! -z "$INPUT_BASELINE" ]; then
   export BASELINE="--baseline=${INPUT_BASELINE}"
 fi
 
-if [ "$INPUT_ANDROID" = true ] ; then
+if [ "$INPUT_ANDROID" = true ]; then
   export ANDROID=--android
 fi
 
@@ -40,8 +40,8 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 echo ktlint version: "$(ktlint --version)"
 
-ktlint --reporter=checkstyle $RELATIVE $ANDROID $BASELINE $INPUT_FILE_GLOB \
-  | reviewdog -f=checkstyle \
+ktlint --reporter=checkstyle $RELATIVE $ANDROID $BASELINE $INPUT_FILE_GLOB |
+  reviewdog -f=checkstyle \
     -name="ktlint" \
     -reporter="${INPUT_REPORTER}" \
     -level="${INPUT_LEVEL}" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,7 @@ export ANDROID=
 export BASELINE=
 
 if [ "$INPUT_KTLINT_VERSION" = "latest" ] ; then
+  echo "Downloading latest..."
   curl -sSL https://api.github.com/repos/pinterest/ktlint/releases/latest \
     | grep "browser_download_url.*ktlint\"" \
     | cut -d : -f 2,3 \
@@ -12,6 +13,7 @@ if [ "$INPUT_KTLINT_VERSION" = "latest" ] ; then
     | wget -qi -\
     && chmod a+x ktlint \
     && mv ktlint /usr/local/bin/
+  echo "Done downloading."
 else
   curl -sSLO https://github.com/pinterest/ktlint/releases/download/"${INPUT_KTLINT_VERSION}"/ktlint \
     && chmod a+x ktlint \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,8 @@ if [ "$INPUT_KTLINT_VERSION" = "latest" ]; then
     grep "browser_download_url.*ktlint\"" |
     cut -d : -f 2,3 |
     tr -d \" |
-    wget -qi - && chmod a+x ktlint &&
+    wget -qi - &&
+    chmod a+x ktlint &&
     mv ktlint /usr/local/bin/
 else
   curl -sSLO https://github.com/pinterest/ktlint/releases/download/"${INPUT_KTLINT_VERSION}"/ktlint &&

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ if [ "$INPUT_KTLINT_VERSION" = "latest" ]; then
     grep "browser_download_url.*ktlint\"" |
     cut -d : -f 2,3 |
     tr -d \" |
-    wget -qi -
+    wget -i -
   chmod a+x ktlint
   mv ktlint /usr/local/bin/
   echo "Done downloading."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ if [ "$INPUT_KTLINT_VERSION" = "latest" ]; then
   mv ktlint /usr/local/bin/
   echo "Done downloading."
 else
-  curl -LO https://github.com/pinterest/ktlint/releases/download/"${INPUT_KTLINT_VERSION}"/ktlint &&
+  curl -sSLO https://github.com/pinterest/ktlint/releases/download/"${INPUT_KTLINT_VERSION}"/ktlint &&
     chmod a+x ktlint &&
     mv ktlint /usr/local/bin/
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,12 +6,13 @@ export BASELINE=
 
 if [ "$INPUT_KTLINT_VERSION" = "latest" ]; then
   echo "Downloading latest..."
-  url=$(curl -L https://api.github.com/repos/pinterest/ktlint/releases/latest | grep "browser_download_url.*ktlint\"")
+  content=$(curl -L https://api.github.com/repos/pinterest/ktlint/releases/latest | grep "browser_download_url.*ktlint\"")
+  echo "$content"
+  url=$(echo "$content" | grep "browser_download_url.*ktlint\"")
   echo "url: ${url}"
-  echo "$url" |
-    cut -d : -f 2,3 |
-    tr -d \" |
-    wget -i -
+  cleaned="$(echo "$url" | cut -d : -f 2,3 | tr -d \")"
+  echo "cleaned: $cleaned"
+  echo "$cleaned" | wget -i -
   chmod a+x ktlint
   mv ktlint /usr/local/bin/
   echo "Done downloading."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ export BASELINE=
 
 if [ "$INPUT_KTLINT_VERSION" = "latest" ]; then
   echo "Downloading latest..."
-  content=$(curl -L https://api.github.com/repos/pinterest/ktlint/releases/latest --header "authorization: Bearer ${SECRETS_GITHUB_TOKEN}")
+  content=$(curl -L https://api.github.com/repos/pinterest/ktlint/releases/latest --header "authorization: Bearer ${INPUT_GITHUB_TOKEN}")
   echo "$content"
   url=$(echo "$content" | grep "browser_download_url.*ktlint\"")
   echo "url: ${url}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ export BASELINE=
 
 if [ "$INPUT_KTLINT_VERSION" = "latest" ]; then
   echo "Downloading latest..."
-  content=$(curl -L https://api.github.com/repos/pinterest/ktlint/releases/latest)
+  content=$(curl -L https://api.github.com/repos/pinterest/ktlint/releases/latest --header "authorization: Bearer ${SECRETS_GITHUB_TOKEN}")
   echo "$content"
   url=$(echo "$content" | grep "browser_download_url.*ktlint\"")
   echo "url: ${url}"


### PR DESCRIPTION
* Fix failure to call GitHub API from time to time resulting in `ktlint: command not found` error
  * Issue is caused by rate limit exceeded: https://github.com/ScaCap/action-ktlint/actions/runs/3773090106/jobs/6414367317
  * Solution: use authenticated calls with `GITHUB_TOKEN`
* Bump `actions/cache` to v3
* Bump alpine to v3.17