### PR TITLE
Adds docs for missing inputs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ Optional. Runs checks against the baseline file provided.
 Optional. Defines the [ktlint](https://ktlint.github.io/) version to use.
 The default value is `latest`.
 
+### `name`
+
+Optional. Reviewdog report name. See [checkstyle-format](https://github.com/reviewdog/reviewdog/tree/master#checkstyle-format) for details.
+The default value is `ktlint`.
+
+### `file_glob`
+
+Optional. Defines a file glob to identify files to be checked.
+The default value is an empty string.
+
 ## Example usage
 
 ```yml


### PR DESCRIPTION
The documentation in README.md is falling behind after release `1.5` and `1.5.1`. This PR adds the missing inputs that are available for the action, but do not show up in the README.md file.