### PR TITLE
fix: apply `code-style=android_studio` starting ktlint v0.49.1

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 ktlint_version=$(ktlint --version)
 echo "ktlint version: $ktlint_version"
 
-if [ "$(printf '%s\n' "0.49.0" "$ktlint_version" | sort -V | head -n1)" = "0.49.0" ]; then
+if [ "$(printf '%s\n' "0.49.1" "$ktlint_version" | sort -V | head -n1)" = "0.49.1" ]; then
   if [ "$INPUT_ANDROID" = true ]; then
     export ANDROID="--code-style=android_studio"
   else


### PR DESCRIPTION
* See https://github.com/pinterest/ktlint/issues/1982
* Command-line flag `--code-style=android_studio` is only effective starting v0.49.1