### PR TITLE
fix: download latest ktlint version without github token

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,11 +6,7 @@ export BASELINE=
 export CUSTOM_RULE_PATH=
 
 if [ "$INPUT_KTLINT_VERSION" = "latest" ]; then
-  curl -sSL https://api.github.com/repos/pinterest/ktlint/releases/latest --header "authorization: Bearer ${INPUT_GITHUB_TOKEN}" |
-    grep "browser_download_url.*ktlint\"" |
-    cut -d : -f 2,3 |
-    tr -d \" |
-    wget -qi - &&
+  curl -sSLO https://github.com/pinterest/ktlint/releases/latest/download/ktlint &&
     chmod a+x ktlint &&
     mv ktlint /usr/local/bin/
 else


### PR DESCRIPTION
### Issue
* See PR: https://github.com/ScaCap/action-ktlint/pull/39
* It is not always possible to use the provided github token to call public GitHub API (e.g. GitHub Enterprise tokens)
* It is possible to use the URL https://github.com/pinterest/ktlint/releases/latest/download/ktlint directly for the latest version