### PR TITLE
chore: drop code-style after v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,19 @@ See reviewdog fail on error [documentation](https://github.com/reviewdog/reviewd
 Optional. Print files relative to the working directory [`true`/`false`]
 The default value is true.
 
-### `android`
+### `android` (deprecated)
 
 Optional. Runs KtLint with [Android Kotlin Style Guide](https://android.github.io/kotlin-guides/style.html) [`true`/`false`]
 The default value is false.
+
+Note: this field has no effect if `ktlint_version` is 1.0.1 or later. `code-style` command-line argument is deprecated in ktlint. Instead, `ktlint_code_style` property in `.editorconfig` 
+needs to be used. Example:
+```editorconfig
+[*.{kt,kts}]
+ktlint_code_style = android_studio
+```
+
+More in https://pinterest.github.io/ktlint/latest/rules/code-styles/
 
 ### `baseline`
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ echo "ktlint version: $ktlint_version"
 
 if [ "$(printf '%s\n' "0.49.1" "$ktlint_version" | sort -V | head -n1)" = "0.49.1" ]; then
   # --code-style is deprecated since 1.0.1 and .editorconfig needs to be used: https://pinterest.github.io/ktlint/latest/rules/code-styles/
-  if [ "$(printf '%s\n' "0.50.0" "$ktlint_version" | sort -V | tail -n1)" = "1.0.0" ]; then
+  if [ "$(printf '%s\n' "1.0.0" "$ktlint_version" | sort -V | tail -n1)" = "1.0.0" ]; then
     if [ "$INPUT_ANDROID" = true ]; then
       export ANDROID="--code-style=android_studio"
     else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,8 +37,8 @@ ktlint_version=$(ktlint --version)
 echo "ktlint version: $ktlint_version"
 
 if [ "$(printf '%s\n' "0.49.1" "$ktlint_version" | sort -V | head -n1)" = "0.49.1" ]; then
-  # --code-style is deprecated and .editorconfig needs to be used: https://pinterest.github.io/ktlint/latest/rules/code-styles/
-  if [ "$(printf '%s\n' "0.50.0" "$ktlint_version" | sort -V | head -n1)" = "0.50.0" ]; then
+  # --code-style is deprecated since 1.0.1 and .editorconfig needs to be used: https://pinterest.github.io/ktlint/latest/rules/code-styles/
+  if [ "$(printf '%s\n' "0.50.0" "$ktlint_version" | sort -V | tail -n1)" = "1.0.0" ]; then
     if [ "$INPUT_ANDROID" = true ]; then
       export ANDROID="--code-style=android_studio"
     else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,10 +37,13 @@ ktlint_version=$(ktlint --version)
 echo "ktlint version: $ktlint_version"
 
 if [ "$(printf '%s\n' "0.49.1" "$ktlint_version" | sort -V | head -n1)" = "0.49.1" ]; then
-  if [ "$INPUT_ANDROID" = true ]; then
-    export ANDROID="--code-style=android_studio"
-  else
-    export ANDROID="--code-style=intellij_idea"
+  # --code-style is deprecated and .editorconfig needs to be used: https://pinterest.github.io/ktlint/latest/rules/code-styles/
+  if [ "$(printf '%s\n' "0.50.0" "$ktlint_version" | sort -V | head -n1)" = "0.50.0" ]; then
+    if [ "$INPUT_ANDROID" = true ]; then
+      export ANDROID="--code-style=android_studio"
+    else
+      export ANDROID="--code-style=intellij_idea"
+    fi
   fi
 else
   if [ "$INPUT_ANDROID" = true ]; then
@@ -55,4 +58,3 @@ ktlint --reporter=checkstyle $CUSTOM_RULE_PATH $RELATIVE $ANDROID $BASELINE $INP
     -level="${INPUT_LEVEL}" \
     -filter-mode="${INPUT_FILTER_MODE}" \
     -fail-on-error="${INPUT_FAIL_ON_ERROR}"
-


### PR DESCRIPTION
* `code-style` command line argument is deprecated https://github.com/pinterest/ktlint/commit/85ef02945eb1e7b94de6e8b4690e94b33c932b5f
* `.editorconfig` needs to be used starting v1.0.1