### PR TITLE
GH-52: upgrade reviewdog to 0.17.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.17.0
 
-ENV REVIEWDOG_VERSION=v0.17.4
+ENV REVIEWDOG_VERSION=v0.17.5
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 


### PR DESCRIPTION
Fixes https://github.com/ScaCap/action-ktlint/issues/52

* Upgrade to latest available version https://github.com/reviewdog/reviewdog/releases/tag/v0.17.5
* The version should include a fix to the issue: 
    *  https://github.com/reviewdog/reviewdog/issues/1696
    * https://github.com/reviewdog/reviewdog/commit/378b92484015bc84734140bddec5bd335bdbf10b