### PR TITLE
deps: update reviewdog to v0.19.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.17.0
 
-ENV REVIEWDOG_VERSION=v0.17.5
+ENV REVIEWDOG_VERSION=v0.19.0
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 


### PR DESCRIPTION
This adds a quality-of-life change of closing outdated discussions: https://github.com/reviewdog/reviewdog/pull/1804