### PR TITLE
use base image from ghcr.io istead of dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.0
+FROM ghcr.io/linuxcontainers/alpine:3.17
 
 ENV REVIEWDOG_VERSION=v0.19.0
 


### PR DESCRIPTION
Since Dockerhub throttles quite quickly, switching to the same base image hosted on ghcr.io.