### PR TITLE
PE-2949: use ECR pull-through cache for ghcr.io image

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: scacap-small
     steps:
       - uses: actions/checkout@v3
       - name: Build the Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxcontainers/alpine:3.17
+FROM 595382802897.dkr.ecr.eu-central-1.amazonaws.com/ghcr-io/linuxcontainers/alpine:3.17
 
 ENV REVIEWDOG_VERSION=v0.19.0
 


### PR DESCRIPTION
JIRA link
https://scalablecapital.atlassian.net/browse/PE-2949

## Summary
- replace ghcr.io/linuxcontainers/alpine with the ECR pull-through cache image

## Notes
- Only OCI references were changed.
- This migrates the image pull to the ECR pull-through cache.